### PR TITLE
Improve deps block detection. Fixes benlime/vscode-hex-pm-intellisense#1.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-hex-pm-intellisense",
-    "version": "0.1.0",
+    "version": "0.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-hex-pm-intellisense",
     "displayName": "hex.pm IntelliSense",
     "description": "Adds IntelliSense for hex.pm dependencies in your Elixir project Mixfile.",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "publisher": "benvp",
     "icon": "images/icon.png",
     "repository": {
@@ -20,17 +20,15 @@
     ],
     "main": "./out/extension",
     "contributes": {
-        "languages": [
-            {
-                "id": "elixir",
-                "aliases": [
-                    "Elixir"
-                ],
-                "extensions": [
-                    ".exs"
-                ]
-            }
-        ]
+        "languages": [{
+            "id": "elixir",
+            "aliases": [
+                "Elixir"
+            ],
+            "extensions": [
+                ".exs"
+            ]
+        }]
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",

--- a/src/shouldProvide.ts
+++ b/src/shouldProvide.ts
@@ -25,19 +25,15 @@ function isCursorInDepsBlock(
   const depsHeadRegex = /def[p]?[\s]+deps[\s]+do$/m; // assumes there is only one `deps` function
   const indexOfDepsHead = leftText.search(depsHeadRegex);
   if (indexOfDepsHead <= -1) {
-    // console.log("cursor NOT in deps block");
     return false;
   }
 
   const depsHeadToCursor = leftText.substr(indexOfDepsHead);
-  // console.log(depsHeadToCursor);
   const depsEndRegex = /^[\s]*end$/m;
   if (depsHeadToCursor.search(depsEndRegex) > -1) {
     // assumes `end` does not appear by itself in a line in deps block
-    // console.log("cursor NOT in deps block");
     return false;
   }
 
-  // console.log("cursor in deps block");
   return true;
 }

--- a/src/shouldProvide.ts
+++ b/src/shouldProvide.ts
@@ -11,14 +11,22 @@ function isMixfile(fileName: String): boolean {
 function isCursorInDepsBlock(document: vscode.TextDocument, position: vscode.Position): boolean {
   // find deps function definition 'defp deps do'
   const fileStartPosition = new vscode.Position(0, 0);
-  const fileEndPosition = new vscode.Position(document.lineCount, document.lineAt(document.lineCount - 1).range.end.character);
   const leftRange = new vscode.Range(fileStartPosition, position);
-  const rightRange = new vscode.Range(position, fileEndPosition);
   const leftText = document.getText(leftRange);
-  const rightText = document.getText(rightRange);
-  const indexOfDepsHead = leftText.indexOf('defp deps do');
-  const indexOfDepsEnd = rightText.indexOf('end');
-  const indexOfNextFunctionHead = rightText.indexOf('def') || rightText.indexOf('defp');
 
-  return indexOfDepsHead > -1 && indexOfDepsEnd > -1 && indexOfDepsEnd < indexOfNextFunctionHead;
+  const indexOfDepsHead = leftText.indexOf('defp deps do'); //assumes rigid formatting of deps function head
+  if (indexOfDepsHead <= -1) {
+    return false;
+  }
+
+  const leftTextDepsHeadToCursor = leftText.substr(indexOfDepsHead);
+  //console.log(leftTextDepsHeadToCursor);
+
+  if (leftTextDepsHeadToCursor.includes('end')) { //assumes end does not appear in the deps block
+    //console.log("cursor NOT in deps block");
+    return false;
+  }
+
+  //console.log("cursor in deps block");
+  return true;
 }

--- a/src/shouldProvide.ts
+++ b/src/shouldProvide.ts
@@ -18,23 +18,22 @@ function isCursorInDepsBlock(
   position: vscode.Position
 ): boolean {
   // find deps function definition 'defp deps do'
-  const fileStartPosition = new vscode.Position(0, 0);
-  const leftRange = new vscode.Range(fileStartPosition, position);
-  const leftText = document.getText(leftRange);
+  const leftText = document.getText(
+    new vscode.Range(new vscode.Position(0, 0), position)
+  );
 
-  const depsHeadRegex = /def[p]?[\s]+deps[\s]+do$/m; //assumes there is only one `deps` function
+  const depsHeadRegex = /def[p]?[\s]+deps[\s]+do$/m; // assumes there is only one `deps` function
   const indexOfDepsHead = leftText.search(depsHeadRegex);
-  // console.log(indexOfDepsHead);
   if (indexOfDepsHead <= -1) {
+    // console.log("cursor NOT in deps block");
     return false;
   }
 
   const depsHeadToCursor = leftText.substr(indexOfDepsHead);
   // console.log(depsHeadToCursor);
-
   const depsEndRegex = /^[\s]*end$/m;
   if (depsHeadToCursor.search(depsEndRegex) > -1) {
-    //assumes `end` does not appear by itself in a line in deps block
+    // assumes `end` does not appear by itself in a line in deps block
     // console.log("cursor NOT in deps block");
     return false;
   }

--- a/src/shouldProvide.ts
+++ b/src/shouldProvide.ts
@@ -1,21 +1,29 @@
 import * as vscode from 'vscode';
 
-export function shouldProvide(document: vscode.TextDocument, position: vscode.Position): boolean {
-  return isMixfile(document.fileName) && isCursorInDepsBlock(document, position);
+export function shouldProvide(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): boolean {
+  return (
+    isMixfile(document.fileName) && isCursorInDepsBlock(document, position)
+  );
 }
 
 function isMixfile(fileName: String): boolean {
   return fileName.endsWith('mix.exs');
 }
 
-function isCursorInDepsBlock(document: vscode.TextDocument, position: vscode.Position): boolean {
+function isCursorInDepsBlock(
+  document: vscode.TextDocument,
+  position: vscode.Position
+): boolean {
   // find deps function definition 'defp deps do'
   const fileStartPosition = new vscode.Position(0, 0);
   const leftRange = new vscode.Range(fileStartPosition, position);
   const leftText = document.getText(leftRange);
 
-  const depsBlockRegex = /def[p]?[\s]+deps[\s]+do$/m; //assumes there is only one `deps` function
-  const indexOfDepsHead = leftText.search(depsBlockRegex);
+  const depsHeadRegex = /def[p]?[\s]+deps[\s]+do$/m; //assumes there is only one `deps` function
+  const indexOfDepsHead = leftText.search(depsHeadRegex);
   // console.log(indexOfDepsHead);
   if (indexOfDepsHead <= -1) {
     return false;
@@ -24,8 +32,9 @@ function isCursorInDepsBlock(document: vscode.TextDocument, position: vscode.Pos
   const depsHeadToCursor = leftText.substr(indexOfDepsHead);
   // console.log(depsHeadToCursor);
 
-  const depsBlockEndRegex = /^[\s]*end$/m;
-  if (depsHeadToCursor.search(depsBlockEndRegex) > -1) { //assumes `end` does not appear by itself in a line in deps block
+  const depsEndRegex = /^[\s]*end$/m;
+  if (depsHeadToCursor.search(depsEndRegex) > -1) {
+    //assumes `end` does not appear by itself in a line in deps block
     // console.log("cursor NOT in deps block");
     return false;
   }

--- a/src/shouldProvide.ts
+++ b/src/shouldProvide.ts
@@ -14,19 +14,22 @@ function isCursorInDepsBlock(document: vscode.TextDocument, position: vscode.Pos
   const leftRange = new vscode.Range(fileStartPosition, position);
   const leftText = document.getText(leftRange);
 
-  const indexOfDepsHead = leftText.indexOf('defp deps do'); //assumes rigid formatting of deps function head
+  const depsBlockRegex = /def[p]?[\s]+deps[\s]+do$/m; //assumes there is only one `deps` function
+  const indexOfDepsHead = leftText.search(depsBlockRegex);
+  // console.log(indexOfDepsHead);
   if (indexOfDepsHead <= -1) {
     return false;
   }
 
-  const leftTextDepsHeadToCursor = leftText.substr(indexOfDepsHead);
-  //console.log(leftTextDepsHeadToCursor);
+  const depsHeadToCursor = leftText.substr(indexOfDepsHead);
+  // console.log(depsHeadToCursor);
 
-  if (leftTextDepsHeadToCursor.includes('end')) { //assumes end does not appear in the deps block
-    //console.log("cursor NOT in deps block");
+  const depsBlockEndRegex = /^[\s]*end$/m;
+  if (depsHeadToCursor.search(depsBlockEndRegex) > -1) { //assumes `end` does not appear by itself in a line in deps block
+    // console.log("cursor NOT in deps block");
     return false;
   }
 
-  //console.log("cursor in deps block");
+  // console.log("cursor in deps block");
   return true;
 }


### PR DESCRIPTION
I tried to simplify the solution and the code in `src/shouldProvide.ts`, removing the need for checks on the text to the right of the cursor. I added some `console.log()` calls as comments for debugging and some assumptions the extension currently makes in order to work.

I tried using regex but things got complicated quickly so I dropped it. But without regex certain assumptions have to be made: eg that the `deps` function doesn't contain `end` as part of an anonymous function or some other block or that there isn't extra whitespace in the head `defp deps do`.

Integration tests would be great for working out more flexible detection of the `deps` block.